### PR TITLE
eliminate dependency on Devel::Symdump

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
-requires "Devel::Symdump" => "2.08";
 requires "Symbol" => "0";
 requires "Test::Builder::Module" => "0.86";
 requires "perl" => "5.006";

--- a/lib/Test/API.pm
+++ b/lib/Test/API.pm
@@ -6,7 +6,6 @@ package Test::API;
 # ABSTRACT: Test a list of subroutines provided by a module
 # VERSION
 
-use Devel::Symdump 2.08 ();
 use Symbol ();
 
 use superclass 'Test::Builder::Module' => 0.86;
@@ -122,9 +121,11 @@ sub _difference {
 
 sub _public_fcns {
     my ($package) = @_;
-    my $symbols = Devel::Symdump->new($package);
+    no strict qw(refs);
     return grep { substr( $_, 0, 1 ) ne '_' }
-      map { ( my $f = $_ ) =~ s/^$package\:://; $f } $symbols->functions;
+      map { ( my $f = $_ ) =~ s/^\*$package\:://; $f }
+      grep { defined(*$_{CODE}) }
+      values(%{"$package\::"});
 }
 
 #--------------------------------------------------------------------------#


### PR DESCRIPTION
I've tested this on Perl 5.8 and 5.18, and it seems to work fine.
