### PR TITLE
eliminate superclass.pm dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,6 @@ requires "Symbol" => "0";
 requires "Test::Builder::Module" => "0.86";
 requires "perl" => "5.006";
 requires "strict" => "0";
-requires "superclass" => "0";
 requires "warnings" => "0";
 
 on 'test' => sub {

--- a/lib/Test/API.pm
+++ b/lib/Test/API.pm
@@ -9,7 +9,8 @@ package Test::API;
 use Devel::Symdump 2.08 ();
 use Symbol ();
 
-use superclass 'Test::Builder::Module' => 0.86;
+use Test::Builder::Module 0.86;
+our @ISA    = qw/Test::Builder::Module/;
 our @EXPORT = qw/public_ok import_ok/;
 
 #--------------------------------------------------------------------------#


### PR DESCRIPTION
I like superclass.pm, but it's non-core, and it requires version.pm, which wasn't added to core until Perl 5.9.
